### PR TITLE
Provide interim sampling capability in exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The exporter will:
 
 * Send it to Honeycomb, who'll then use it to compensate their `COUNT` and other visualised data.
 
-Please treat this as an interim API. We trust the OpenTelemetry specification will evolve to cover
+Please treat this as an off-API workaround. We trust the OpenTelemetry specification will evolve to cover
 this use case, after which you'll be able to get this result without an implementation kludge.
 
 <!-- CDOC !-->

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,6 +6,9 @@ config :opentelemetry,
       scheduled_delay_ms: 1,
       exporter:
         {OpenTelemetry.Honeycomb.Exporter,
-         http_module: MockedHttpBackend, http_options: [], write_key: "HONEYCOMB_WRITEKEY"}
+         http_module: MockedHttpBackend,
+         http_options: [],
+         samplerate_key: "...samplerate",
+         write_key: "HONEYCOMB_WRITEKEY"}
     }
   ]

--- a/lib/open_telemetry/honeycomb.ex
+++ b/lib/open_telemetry/honeycomb.ex
@@ -3,6 +3,7 @@ defmodule OpenTelemetry.Honeycomb do
              |> File.read!()
              |> String.split("<!-- MDOC !-->")
              |> Enum.fetch!(1)
+             |> (&Regex.replace(~R{\(\#\K(?=[a-z][a-z0-9-]+\))}, &1, "module-")).()
 
   @doc "Get the version string for the OpenTelemetry Honeycomb exporter."
   def version do

--- a/lib/open_telemetry/honeycomb/attributes.ex
+++ b/lib/open_telemetry/honeycomb/attributes.ex
@@ -7,6 +7,7 @@ defmodule OpenTelemetry.Honeycomb.Attributes do
     |> File.read!()
     |> String.split("<!-- ADOC !-->")
     |> Enum.fetch!(1)
+    |> (&Regex.replace(~R{\(\#\K(?=[a-z][a-z0-9-]+\))}, &1, "module-")).()
   }
   """
 
@@ -111,6 +112,7 @@ defmodule OpenTelemetry.Honeycomb.Attributes do
     |> File.read!()
     |> String.split("<!-- TRIMDOC !-->")
     |> Enum.fetch!(1)
+    |> (&Regex.replace(~R{\(\#\K(?=[a-z][a-z0-9-]+\))}, &1, "module-")).()
   }
   """
   def trim_long_strings({k, <<_::binary-size(@hc_value_limit)>> = v}), do: {k, v}

--- a/lib/open_telemetry/honeycomb/config.ex
+++ b/lib/open_telemetry/honeycomb/config.ex
@@ -39,6 +39,7 @@ defmodule OpenTelemetry.Honeycomb.Config do
     |> File.read!()
     |> String.split("<!-- CDOC !-->")
     |> Enum.fetch!(1)
+    |> (&Regex.replace(~R{\(\#\K(?=[a-z][a-z0-9-]+\))}, &1, "module-")).()
   }
   """
 
@@ -47,25 +48,14 @@ defmodule OpenTelemetry.Honeycomb.Config do
   alias OpenTelemetry.Honeycomb.Json
 
   @typedoc """
-  Configuration option for the OpenTelemetry Honeycomb exporter, giving:
-
-  * `api_endpoint`: the API endpoint
-  * `attribute_map`: a map to control dataset attributes used for span properties (see below)
-  * `dataset`: the Honeycomb dataset name
-  * `http_module`: the HTTP back end module (see `Http`)
-  * `http_options`: options to pass to the HTTP back end (see `Http`)
-  * `json_module`: the HTTP back end module (see `Json`)
-  * `write_key`: the write key
-
-  If the `write_key` is absent or `nil`, the exporter replaces your `http_module` with
-  `OpenTelemetry.Honeycomb.Http.WriteKeyMissingBackend` to prevent spamming Honeycomb with
-  unauthenticated requests.
+  Configuration option for the OpenTelemetry Honeycomb exporter.
   """
   @type config_opt ::
           {:api_endpoint, String.t()}
           | {:attribute_map, AttributeMap.t()}
           | {:dataset, String.t()}
           | {:write_key, String.t() | nil}
+          | {:samplerate_key, String.t() | nil}
           | Http.config_opt()
           | Json.config_opt()
 

--- a/test/opentelemetry/honeycomb/sampling_test.exs
+++ b/test/opentelemetry/honeycomb/sampling_test.exs
@@ -1,0 +1,59 @@
+defmodule OpenTelemetry.Honeycomb.SamplingTest do
+  use ExUnit.Case, async: false
+
+  require OpenTelemetry.Tracer
+  require OpenTelemetry.Span
+
+  import Mox, only: [set_mox_from_context: 1, verify_on_exit!: 1]
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  @attempts 100
+
+  test "#{@attempts} spans with a sample rate of 4" do
+    test_pid = self()
+
+    samplerate_key =
+      :opentelemetry
+      |> Application.get_all_env()
+      |> get_in([:processors, :ot_batch_processor, :exporter, Access.elem(1), :samplerate_key])
+
+    Mox.expect(MockedHttpBackend, :request, fn :post, _, _, body, _ ->
+      try do
+        assert events = body |> IO.iodata_to_binary() |> Poison.decode!()
+        assert length(events) > 1, "opportunity for VERY rare build failure"
+
+        replies =
+          for %{"data" => data, "samplerate" => samplerate} <- events do
+            refute samplerate == 1, "sample rate not set"
+            refute samplerate_key in Map.keys(data), "samplerate_key #{samplerate_key} not popped"
+            %{"status" => 202}
+          end
+
+        send(test_pid, {:mock_result, :ok})
+        {:ok, 200, [], Poison.encode!(replies)}
+      rescue
+        e ->
+          send(test_pid, {:mock_result, :error, e})
+          {:ok, 400, [], "[]"}
+      end
+    end)
+
+    for n <- 1..@attempts do
+      OpenTelemetry.Tracer.with_span "some-span" do
+        OpenTelemetry.Span.set_attribute("n", n)
+        OpenTelemetry.Span.set_attribute(samplerate_key, 4)
+
+        OpenTelemetry.Span.add_events([
+          OpenTelemetry.event("event.name", [{"event.attr1", "event.value1"}])
+        ])
+      end
+    end
+
+    receive do
+      {:mock_result, :ok} -> :ok
+      {:mock_result, :error, e} -> raise e
+    end
+  end
+end


### PR DESCRIPTION
There's plenty of progress on the OT specification. If you can wait, you don't need to use this capability. Reading material:

- [Sampling Working Group Gitter](https://gitter.im/open-telemetry/sampling-wg)
- PR: Proposal for `sampling.priority`: open-telemetry/oteps#107
- PR: Add `ParentNotRemoteOrElse` and fix `Probability` sampler definition open-telemetry/opentelemetry-specification#610
- PR: Add requirements for probability sampler  open-telemetry/opentelemetry-specification#611

As the README change puts it:

> Please treat this as an off-API workaround. We trust the OpenTelemetry specification will evolve to cover this use case, after which you'll be able to get this result without an implementation kludge.

That said, some Honeycomb customers need to be able to sample _right now_ because of a change in their pricing model. It's literally a choice between sampling in a Honeycomb-sympathetic way, or turning it off. So, this branch provides a workaround: 

* You set some attribute on your spans _eg._ `hc_sample` to indicate your preferred sample rate, as a positive integer: 4 means you're dropping 75% of spans

* You configure the exporter with `samplerate_key` set to something _eg._ `"hc_sample"`

* The exporter _pops `"hc_sample"` out of the attribute map_ so it's no longer confusable for a measurement, and _moves it to the HC `samplerate` key

* The exporter also drops all but 1 in `samplerate` spans before export

It's crude, but it'll do for now.