### PR TITLE
Handle atom values

### DIFF
--- a/lib/open_telemetry/honeycomb/attributes.ex
+++ b/lib/open_telemetry/honeycomb/attributes.ex
@@ -76,6 +76,7 @@ defmodule OpenTelemetry.Honeycomb.Attributes do
       ":" <> repr -> {k, repr}
       repr -> {k, repr}
     end
+    |> clean_pair()
   end
 
   # Flatten maps:

--- a/test/opentelemetry/honeycomb/attributes_cleaning_test.exs
+++ b/test/opentelemetry/honeycomb/attributes_cleaning_test.exs
@@ -39,6 +39,10 @@ defmodule OpenTelemetry.Honeycomb.Attributes.CleaningTest do
       assert %{pid: pid} |> Attributes.clean() == [{"pid", "#PID<0.23.0>"}]
     end
 
+    test "atoms" do
+      assert %{atom: :ok} |> Attributes.clean() == [{"atom", "ok"}]
+    end
+
     test "ports" do
       port = :erlang.list_to_port('#Port<0.23>')
       assert %{port: port} |> Attributes.clean() == [{"port", "#Port<0.23>"}]


### PR DESCRIPTION
edit: Ah, I figured it out.

The `clean_pair({k, v}) when is_atom(v)` head needed to call `clean_pair()` again so it gets into the block with the `is_binary` guard and gets wrapped in a list with everything else.

```elixir
defp clean_pair({k, v})
     when is_number(v) or
          is_binary(v) or
          is_boolean(v),
     do: [{k, v}]
```

exception:

```elixir
# 21:21:56.715 [info]  exporter threw exception: exporter=OpenTelemetry.Honeycomb.Exporter :error:
%Protocol.UndefinedError{
  description: "",
  protocol: Enumerable,
  value: {"db.type", "sql"}
}
stacktrace = [
  {Enumerable, :impl_for!, 1, [file: 'lib/enum.ex', line: 1]},
  {Enumerable, :reduce, 3, [file: 'lib/enum.ex', line: 141]},
  {Enum, :reverse, 1, [file: 'lib/enum.ex', line: 3383]},
  {Enum, :to_list, 1, [file: 'lib/enum.ex', line: 2984]},
  {Enum, :flat_map_list, 2, [file: 'lib/enum.ex', line: 3345]},
  {OpenTelemetry.Honeycomb.Attributes, :clean, 1, [file: 'lib/open_telemetry/honeycomb/attributes.ex', line: 60]},
  {OpenTelemetry.Honeycomb.Event, :from_ot_span, 3, [file: 'lib/open_telemetry/honeycomb/event.ex', line: 69]},
  {Enum, :flat_map_list, 2, [file: 'lib/enum.ex', line: 3343]},
  {OpenTelemetry.Honeycomb.Exporter, :export_loaded, 3, [file: 'lib/open_telemetry/honeycomb/exporter.ex', line: 88]},
  {
    :ot_batch_processor,
    :export,
    3,
    [file: '/Users/marc/Code/marcdel/opentelemetry_honeycomb/deps/opentelemetry/src/ot_batch_processor.erl', line: 287]
  },
  {
    :ot_batch_processor,
    :send_spans,
    3,
    [file: '/Users/marc/Code/marcdel/opentelemetry_honeycomb/deps/opentelemetry/src/ot_batch_processor.erl', line: 273]
  }
]
```