### PR TITLE
Document and allow Jason to be used as the encoder

### DIFF
--- a/lib/open_telemetry/honeycomb/json.ex
+++ b/lib/open_telemetry/honeycomb/json.ex
@@ -5,18 +5,18 @@ defmodule OpenTelemetry.Honeycomb.Json do
   The OpenTelemetry Honeycomb Exporter uses a `Jason`-style JSON encoder via a behaviour so you
   can adapt it to your preferred JSON encoder or decode/encode options.
 
-  To use `Poison`, install it. The exporter defaults `json_backend` to
+  To use `Poison`, install it. The exporter defaults `json_module` to
   `OpenTelemetry.Honeycomb.Json.PoisonBackend`, which adapts `Poison` to the subset of the
   `Jason` API we document with this behaviour.
 
-  To use `Jason`, install it and configure it as the `json_backend`:
+  To use `Jason`, install it and configure it as the `json_module`:
 
   ```
   config :opentelemetry,
     processors: [
       otel_batch_processor: %{
-        exporter: OpenTelemetry.Honeycomb.Exporter,
-        json_backend: Jason
+        exporter:
+          {OpenTelemetry.Honeycomb.Exporter, json_module: Jason}
       }
     ]
   ```

--- a/lib/open_telemetry/honeycomb/json/jason_backend.ex
+++ b/lib/open_telemetry/honeycomb/json/jason_backend.ex
@@ -1,0 +1,4 @@
+if Code.ensure_loaded?(Jason) do
+  require Protocol
+  Protocol.derive(Jason.Encoder, OpenTelemetry.Honeycomb.Event)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -29,9 +29,7 @@ defmodule OpenTelemetry.Honeycomb.MixProject do
   end
 
   def application do
-    [
-      extra_applications: [:logger, :hackney, :poison]
-    ]
+    []
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]


### PR DESCRIPTION
Addresses #12, namely that BEAM was trying to start `poison.app` but I'd opted to use Jason.

```
$ iex -S mix # without poison as a dependency
** (Mix) Could not start application poison: could not find application file: poison.app
```

Also corrects an issue I had where Jason wanted an explicit encoding implementation but one was lacking for the Event.

```
description: "Jason.Encoder protocol must always be explicitly implemented.\n\nIf you own the struct, you can derive the implementation specifying which fields should be encoded to JSON:\n\n    @derive {Jason.Encoder, only: [....]}\n    defstruct ...\n\nIt is also possible to encode all fields, although this should be used carefully to avoid accidentally leaking private information when new fields are added:\n\n    @derive Jason.Encoder\n    defstruct ...\n\nFinally, if you don't own the struct you want to encode to JSON, you may use Protocol.derive/3 placed outside of any module:\n\n    Protocol.derive(Jason.Encoder, NameOfTheStruct, only: [...])\n    Protocol.derive(Jason.Encoder, NameOfTheStruct)\n",
  protocol: Jason.Encoder,
  value: %OpenTelemetry.Honeycomb.Event{
    data: %{
```

We do own the struct but don't know if we'll be using Jason, so mimic the `poison_backend` to use a `Code.ensure_loaded?` block for deciding whether or not to do that.