### PR TITLE
chore: Telemetry Version Upgrade and Apple Silicone Support

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.9.4-otp-22
-erlang 22.1.8
+erlang 22.3.4.26

--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,7 @@ defmodule OpenTelemetry.Honeycomb.MixProject do
       {:opentelemetry, "~> 0.5.0"},
       {:opentelemetry_api, "~> 0.5.0"},
       {:poison, ">= 1.5.0", optional: true},
-      {:telemetry, "~> 0.4.0"}
+      {:telemetry, ">= 0.4.0"}
     ]
   end
 


### PR DESCRIPTION
Some other packages (hammox, for example) now require a version of `:telemetry` greater than `1.0`. Although there are no breaking changes between `0.4` and `1.0`, pinning the version to `0.4.0` results in the following error:

```
Because hammox >= 0.7.0 depends on telemetry ~> 1.0 and every version of opentelemetry_honeycomb depends on telemetry ~> 0.4.0, hammox >= 0.7.0 is incompatible with opentelemetry_honeycomb.
And because your app depends on hammox ~> 0.7.0, no version of opentelemetry_honeycomb is allowed.
So, because your app depends on opentelemetry_honeycomb ~> 0.5.0-rc.1, version solving failed.
```

Also, the version of erlang currently being used does not support Apple Silicone, so I upgraded to the latest `22.X` release, so I could make the required change.